### PR TITLE
Implementing float type support

### DIFF
--- a/yascm.c
+++ b/yascm.c
@@ -121,6 +121,13 @@ object *make_fixnum(int64_t val)
 	return obj;
 }
 
+object *make_floatnum(long double val)
+{
+	object *obj = create_object(FLOATNUM);
+	obj->float_val = val;
+	return obj;
+}
+
 object *make_emptylist(void)
 {
 	return Nil;
@@ -267,6 +274,9 @@ void object_print(const object *obj)
 	case FIXNUM:
 		printf("%ld", obj->int_val);
 		break;
+	case FLOATNUM:
+		printf("%LF", obj->float_val);
+		break;    
 	case KEYWORD:
 		printf("<keyword>");
 		break;
@@ -316,10 +326,15 @@ static void add_primitive(object *env, char *name, Primitive *func,
 
 static object *prim_plus(object *env, object *args)
 {
-	int64_t ret;
-	for (ret = 0; args != Nil; args = args->cdr)
-		ret += (car(args)->int_val);
-	return make_fixnum(ret);
+	long double ret;
+  object_type type = FIXNUM;
+	for (ret = 0; args != Nil; args = args->cdr) {
+    ret += getval(car(args));
+    if(car(args)->type == FLOATNUM) {
+      type = FLOATNUM;
+    }
+  }
+  return make_numval(ret, type);
 }
 
 static int list_length(object *list)
@@ -333,28 +348,87 @@ static int list_length(object *list)
 	}
 }
 
+object *make_numval(long double val, object_type type)
+{
+  object *obj = NULL;
+  
+  if(type == FIXNUM) {
+  	obj = create_object(FIXNUM);
+  	obj->int_val = val;
+  } else if(type == FLOATNUM) {
+  	obj = create_object(FLOATNUM);
+  	obj->float_val = val;
+  }
+
+	return obj;
+}
+
+object *make_numobj(object* val)
+{
+  object *obj = NULL;
+  
+  if(val->type == FIXNUM) {
+  	obj = create_object(FIXNUM);
+  	obj->int_val = val->int_val;
+  } else if(val->type == FLOATNUM) {
+  	obj = create_object(FLOATNUM);
+  	obj->float_val = val->float_val;
+  }
+
+	return obj;
+}
+
+long double getval(object* val) 
+{
+  if(val->type == FIXNUM) {
+    return val->int_val;
+  } else if(val->type == FLOATNUM) {
+    return val->float_val;
+  }
+}
+
 static object *prim_sub(object *env, object *args)
 {
-	int64_t ret;
+	long double ret;
+  object_type type = FIXNUM;
+  ret = getval(car(args));
+  if(car(args)->type == FLOATNUM) {
+    type = FLOATNUM;
+  }  
 	if (list_length(args) == 1)
-		return make_fixnum(-car(args)->int_val);
-	ret = car(args)->int_val;
-	for (args = args->cdr; args != Nil; args = args->cdr)
-		ret -= (car(args)->int_val);
-	return make_fixnum(ret);
+		ret = -ret;  
+	for (args = args->cdr; args != Nil; args = args->cdr) {
+    ret -= getval(car(args));
+    if(car(args)->type == FLOATNUM) {
+      type = FLOATNUM;
+    }
+  }
+  return make_numval(ret, type);
 }
 
 static object *prim_mul(object *env, object *args)
 {
-	int64_t ret;
-	for (ret = 1; args != Nil; args = args->cdr)
-		ret *= (car(args)->int_val);
-	return make_fixnum(ret);
+	long double ret;
+  object_type type = FIXNUM;
+	for (ret = 1; args != Nil; args = args->cdr) {
+    ret *= getval(car(args));
+    if(car(args)->type == FLOATNUM) {
+      type = FLOATNUM;
+    }
+  }
+  return make_numval(ret, type);
 }
 
 static object *prim_quotient(object *env, object *args)
 {
-	return make_fixnum(args->car->int_val / cadr(args)->int_val);
+  long double ret = getval(args->car) / getval(cadr(args));
+  object_type type = FIXNUM;
+  if(args->car->type == FLOATNUM || cadr(args)->type == FLOATNUM) {
+    type = FLOATNUM;
+  } else {
+    type = FIXNUM;
+  }
+	return make_numval(ret, type);
 }
 
 static object *prim_cons(object *env, object *args)

--- a/yascm.h
+++ b/yascm.h
@@ -84,6 +84,7 @@ object *make_bool(bool val);
 object *make_char(char val);
 object *make_string(const char *val);
 object *make_fixnum(int64_t val);
+object *make_floatnum(long double val);
 object *make_emptylist(void);
 object *make_symbol(const char *name);
 object *make_quote(object *obj);
@@ -92,5 +93,8 @@ object *make_env(object *var, object *up);
 object *eval(object *env, object *obj);
 void object_print(const object *obj);
 void eof_handle(void);
+long double getval(object* val);
+object *make_numval(long double val, object_type type);
+object *make_numobj(object* val);
 
 #endif

--- a/yascm_bison.y
+++ b/yascm_bison.y
@@ -50,7 +50,8 @@ void yyerror(struct object_s **obj, const char *s);
 
 %type <s> string
 %type <var> object
-%type <n> number
+%type <n> inumber
+%type <d> fnumber
 %type <var> emptylist
 %type <var> quote_list
 %type <var> pair
@@ -69,8 +70,8 @@ exp: object {*obj = $1; YYACCEPT;}
 string: DOUBLE_QUOTE STRING_T DOUBLE_QUOTE {$$ = $2;}
       | DOUBLE_QUOTE DOUBLE_QUOTE {$$ = "\"";}
 
-number: FIXNUM_T {$$ = $1;}
-      | FLOATNUM_T {printf("float: not support now\n");}
+inumber: FIXNUM_T {$$ = $1;}
+fnumber: FLOATNUM_T {$$ = $1;}
 
 emptylist: LP RP 
 
@@ -88,7 +89,8 @@ list: LP list_end {$$ = $2;}
 
 object: TRUE_T		{$$ = make_bool(true);}
       | FALSE_T		{$$ = make_bool(false);}
-      | number		{$$ = make_fixnum($1);}
+      | inumber		{$$ = make_fixnum($1);}
+      | fnumber		{$$ = make_floatnum($1);}
       | CHAR_T		{$$ = make_char($1);}
       | string		{$$ = make_string($1);}
       | SYMBOL_T	{$$ = make_symbol($1);}

--- a/yascm_flex.l
+++ b/yascm_flex.l
@@ -49,7 +49,10 @@ CHAR_VAL (newline|space|[^{WS}]|x[0-9A-F]+)
 	yylval.n = strtoll(yytext, NULL, 10);
 	return FIXNUM_T;
 }
-[-]?{DIG}?"."{DIG}	{return FLOATNUM_T;}
+[-]?{DIG}?"."{DIG}	{
+  yylval.d = strtod(yytext, NULL);
+  return FLOATNUM_T;
+}
 
 #\\	{BEGIN(EXPECT_CHAR);}
 <EXPECT_CHAR>{CHAR_VAL} {


### PR DESCRIPTION
This updates the grammar to support a floating point token, and creates helper functions to create a number with the appropriate type semantics (i.e., (+ FLOATNUM FIXNUM) returns a FLOATNUM but (+ FIXNUM FIXNUM) returns a FIXNUM).  Updates the prim_* arithmetic functions to get and return the appropriate value types.